### PR TITLE
Fix merge issue - remove local re-declaration of CMutableTransaction

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -162,7 +162,6 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn, CWallet* pwallet, 
         boost::this_thread::interruption_point();
         pblock->nTime = GetAdjustedTime();
         pblock->nBits = GetNextWorkRequired(pindexPrev, pblock);
-        CMutableTransaction txCoinStake;
         int64_t nSearchTime = pblock->nTime; // search to current time
         bool fStakeFound = false;
         if (nSearchTime >= nLastCoinStakeSearchTime) {


### PR DESCRIPTION
txCoinStake should not be declared local, because it is also used further down the function: https://github.com/Kokary/techsquad111-wagerr/blob/b4fb859f25d80579fbaa71353c8dbc6652ae9ed8/src/miner.cpp#L486
